### PR TITLE
Enhance MAX32690 port: README instructions, environment setup, and SAVELOG support

### DIFF
--- a/ports/max32650/.gitignore
+++ b/ports/max32650/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build logs
+logs/
+*.log

--- a/ports/max32650/Makefile
+++ b/ports/max32650/Makefile
@@ -5,28 +5,82 @@ include ../make.mk
 include port.mk
 include ../rules.mk
 
-#------------------------------------------
+################################################################################
+# Optional Save Log Support
+################################################################################
+ifeq ($(SAVELOG),1)
+    TIMESTAMP := $(shell date +%Y%m%d_%H%M%S)
+    LOG_SUFFIX = _$(TIMESTAMP).log
+endif
+
+################################################################################
 # Self-update
-#------------------------------------------
-self-update: $(BUILD)/$(OUTNAME).bin
-	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py --carray $^ -o apps/self_update/_build/bootloader_bin.c
+################################################################################
+self-update:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update
+	@echo "Building self-update application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update/self-update$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update uf2
+endif
 
 self-update-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update-clean
+	@echo "Cleaning self-update application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update-clean/self-update-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update clean
+endif
 
-#---------- Erase Firmware ----------
-# Compile apps/erase_firmware/erase_firmware.c
+################################################################################
+# Erase Firmware
+################################################################################
 erase-firmware:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware
+	@echo "Building erase-firmware application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware/erase-firmware$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware uf2
+endif
 
 erase-firmware-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware-clean
+	@echo "Cleaning erase-firmware application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware-clean/erase-firmware-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware clean
+endif
 
-#---------- Blinky ----------
-# Compile apps/blinky/blinky.c
+################################################################################
+# Blinky
+################################################################################
 blinky:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky
+	@echo "Building blinky application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky/blinky$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky uf2
+endif
 
 blinky-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky-clean
+	@echo "Cleaning blinky application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky-clean/blinky-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky clean
+endif
+
+################################################################################
+# Clean Logs
+################################################################################
+clean-logs:
+	@echo "Cleaning all log files..."
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/self_update/logs
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/blinky/logs

--- a/ports/max32650/README.md
+++ b/ports/max32650/README.md
@@ -1,0 +1,378 @@
+# TinyUF2 - MAX32650 Port
+
+This folder contains the port of TinyUF2 for Analog Devices' MAX32650 MCU.
+
+## Navigation
+
+- [Requirements](#requirements)
+  - [Requirements for Linux/macOS (Generic)](#requirements-for-linuxmacos-generic)
+  - [Requirements for Windows (Using MSDK — Optional)](#requirements-for-windows-using-msdk--optional)
+- [MSDK Windows Environment Setup](#msdk-windows-environment-setup)
+- [Available Boards](#available-boards)
+- [Building the Bootloader](#building-the-bootloader)
+- [Building Demo Applications](#building-demo-applications)
+  - [To Build Individual Applications](#to-build-individual-applications)
+  - [To Clean Individual Applications](#to-clean-individual-applications)
+- [Flashing the Bootloader](#flashing-the-bootloader)
+  - [J-Link vs OpenOCD](#j-link-vs-openocd)
+  - [Flashing with J-Link](#1-j-link-default)
+  - [Flashing with OpenOCD (MSDK)](#2-openocd-from-msdk-optional)
+- [Notes on SAVELOG=1](#notes-on-savelog1)
+- [Cleaning Logs](#cleaning-logs)
+- [Flashing Example Applications](#flashing-example-applications)
+  - [Flashing via Drag-and-Drop](#flashing-via-drag-and-drop)
+  - [Re-Entering Bootloader Mode](#re-entering-bootloader-mode)
+- [Port Directory Structure](#port-directory-structure)
+
+
+<br>
+
+## Requirements
+
+This guide focuses on building TinyUF2 for Analog Devices' MAX32 parts.  
+It is written with Windows users in mind using the **MSDK**, but TinyUF2 is fully portable and can be built with a standard toolchain on Linux and macOS.
+
+
+### Requirements for Linux/macOS (Generic)
+
+You do **not** need the MSDK to build TinyUF2 on Linux or macOS.  
+All you need is a basic toolchain:
+
+- **GNU ARM Toolchain** (`arm-none-eabi-gcc`) available in your `PATH`
+- **make**
+- **git** (required for submodules)
+- **SDK Depencencies** 
+
+
+### Installing SDK Dependencies
+```bash 
+python tools/get_deps.py max32
+```
+or
+```bash
+python tools/get_deps.py --board max32650evkit
+```
+
+#### macOS Dependency Install
+```bash
+brew install arm-none-eabi-gcc make git
+```
+
+#### Ubuntu Dependency Install
+```bash
+sudo apt update
+sudo apt install gcc-arm-none-eabi make git
+```
+
+<br><br>
+
+```bash
+# Example usage:
+cd ports/max32650evkit/
+make BOARD=max32650evkit all
+```
+
+---
+
+### Requirements for Windows (Using MSDK — Optional)
+
+If you're using Analog Devices' [MSDK](https://github.com/analogdevicesinc/msdk), it includes:
+
+- Pre-configured **GNU ARM Toolchain**
+- **MSYS2** terminal environment
+- Optional **OpenOCD** with MAX32 flash support
+
+Download MSDK from:  
+[Analog Devices Embedded Software Center (MaximSDK)](https://www.analog.com/en/resources/evaluation-hardware-and-software/embedded-development-software/software-download.html?swpart=SFW0010820B)
+
+You will need:
+
+- ARM GNU Toolchain (`arm-none-eabi-gcc`) — *included with MSDK*
+- `make`:
+  - MSDK MSYS2: `C:/MaximSDK/Tools/MSYS2/usr/bin/make.exe`
+  - System-wide MSYS2: `C:/msys64/usr/bin/make.exe`
+- `git` (may need to be installed inside MSYS2):
+  ```bash
+  pacman -S git
+  ```
+
+If needed, set `MAXIM_PATH` to point to your MSDK installation:
+
+```bash
+export MAXIM_PATH=/c/MaximSDK
+```
+
+
+<br>
+
+## MSDK (Windows) Environment Setup
+
+### 1. Using MSDK's MSYS2
+
+Open MSYS2 (`mingw32.exe` or `mingw64.exe`) from:
+
+```
+C:/MaximSDK/Tools/MSYS2/
+```
+
+No further setup is needed — the required ARM toolchain should be available.
+
+### 2. Using a System-wide MSYS2 or mingw (Alternative)
+
+If you are using your own MSYS2 or mingw installation (not MSDK’s MSYS2), you must manually add the MSDK's GNUTools to your PATH before building:
+
+```bash
+export PATH="/c/MaximSDK/Tools/GNUTools/10.3/bin/:$PATH"
+```
+
+Or in one-line command for building:
+
+```bash
+PATH="/c/MaximSDK/Tools/GNUTools/10.3/bin/:$PATH" make BOARD=max32650evkit blinky erase-firmware self-update
+```
+
+(Adjust the path if your MSDK installation is in a different location.)
+
+<br>
+
+## Available Boards
+
+Each port supports multiple hardware platforms.  
+The specific boards available for each device can be found inside:
+
+```
+ports/maxxxxxx/boards/
+```
+
+For example, for MAX32650:
+
+```
+tinyuf2/ports/max32650/boards/
+    max32650evkit
+    max32650fthr
+```
+
+When building or flashing, make sure to specify a valid `BOARD` name from the available list:
+
+```bash
+make BOARD=max32650evkit all
+make BOARD=max32650evkit flash
+```
+
+Otherwise, the build will fail if an invalid board name is provided.
+
+<br>
+
+## Building the Bootloader
+
+1. Open your MSYS2 terminal (preferably MSDK’s).
+2. Navigate to the port folder for MAX32650:
+
+```bash
+cd ports/max32650
+```
+
+3. Build the TinyUF2 bootloader:
+
+```bash
+make BOARD=max32650evkit all
+```
+
+
+Output files will appear in `_build/` and build logs under `apps/$(APP)/logs/`.
+
+
+<br>
+
+## Building Demo Applications
+
+TinyUF2 for MAX32650 includes three demo applications:
+- **Blinky** (`apps/blinky`)
+- **Erase Firmware** (`apps/erase_firmware`)
+- **Self-Update** (`apps/self_update`)
+
+### To Build Individual Applications:
+
+```bash
+make BOARD=max32650evkit blinky
+make BOARD=max32650evkit erase-firmware
+make BOARD=max32650evkit self-update
+```
+
+### To Clean Individual Applications:
+
+```bash
+make BOARD=max32650evkit blinky-clean
+make BOARD=max32650evkit erase-firmware-clean
+make BOARD=max32650evkit self-update-clean
+```
+
+You can add `SAVELOG=1` to any of these commands to generate a saved build log.
+
+```bash
+ make BOARD=max32650evkit SAVELOG=1 blinky erase-firmware self-update
+```
+
+<br>
+
+## Flashing the Bootloader
+
+
+### J-Link vs OpenOCD
+
+TinyUF2 supports two main ways to flash firmware:
+
+- **J-Link** (default): Uses SEGGER's proprietary debug probe. Supports fast, reliable flashing and debugging over SWD or JTAG. Requires a J-Link device and SEGGER drivers.
+  
+- **OpenOCD (MSDK)**: Open-source tool for programming/debugging via CMSIS-DAP or other adapters.  
+  The MSDK includes a custom version of OpenOCD that supports MAX32 devices, since official OpenOCD does not yet have MAX32 flash algorithm support.
+
+
+<br>
+
+`make flash` will use **J-Link** by default.  
+`make flash-msdk` to use the **OpenOCD** path with CMSIS-DAP.
+
+
+
+### 1. J-Link (default)
+
+To flash using a J-Link debugger:
+
+```bash
+make BOARD=max32650evkit flash
+```
+
+To erase before flashing:
+
+```bash
+make BOARD=max32650evkit erase flash
+```
+
+### 2. OpenOCD from MSDK (optional)
+
+If you prefer OpenOCD and you have it installed through MSDK:
+
+```bash
+make BOARD=max32650evkit flash-msdk
+```
+
+Make sure `MAXIM_PATH` is correctly set to the MSDK base folder. If your default installation of the MSDK is not `C:/MaximSDK` you can pass the MaximSDK directory's location...
+
+```bash
+make BOARD=max32650evkit MAXIM_PATH=C:/MaximSDK flash-msdk
+```
+
+> ⚠️ **Note:**
+> Optional flash option when running within an installed MSDK to use OpenOCD. Mainline OpenOCD does not yet have the MAX32's flash algorithm integrated. If the MSDK is installed, flash-msdk can be run to utilize the the modified openocd with the algorithms.
+
+<br>
+
+## Notes on SAVELOG=1
+
+Log export options are available for demo apps.
+
+If `SAVELOG=1` is set during a build:
+
+- Output logs are automatically saved into a `logs/` folder inside each application.
+- Each application target (e.g., `blinky`, `blinky-clean`) has its own separate subfolder and timestamped `.log` files.
+- Log files are ignored from Git version control.
+
+Example:
+
+```
+apps/blinky/logs/blinky/blinky_20250425_134500.log
+apps/blinky/logs/blinky-clean/blinky-clean_20250425_134512.log
+```
+
+<br>
+
+## Cleaning Logs
+
+You can remove all saved build logs across all apps by running:
+
+```bash
+make BOARD=max32650evkit clean-logs
+```
+
+This deletes all `logs/` directories under `apps/blinky`, `apps/erase_firmware`, and `apps/self_update`.
+
+
+<br>
+
+
+## Flashing Example Applications
+
+After building any of the demo applications (Blinky, Erase Firmware, or Self-Update), a UF2 file will be generated in:
+
+```
+apps/<application>/_build/<board>/<application>-<board>.uf2
+```
+
+For example:
+
+```
+apps/blinky/_build/<board>/blinky-<board>.uf2
+```
+
+### Flashing via Drag-and-Drop
+
+1. **Enter bootloader mode** on your board:
+   - Typically, perform a **double-tap on the reset button** within **500 milliseconds**.
+   - The board will appear as a **USB mass storage device** (for example, named `TINYUF2`) in your operating system's **File Explorer** (Windows) or **Finder** (macOS) or **File Manager** (Linux).
+
+2. **Using your file explorer**, locate the `.uf2` file you built, and **drag and drop** it onto the mounted TinyUF2 USB drive.
+
+3. The board will automatically reboot and begin running the new application.
+
+### Re-Entering Bootloader Mode
+
+To flash a different application or return to bootloader mode:
+
+- Perform another **double-tap** of the reset button within 500 milliseconds.
+- The board will reappear as a USB mass storage device for new UF2 flashing.
+
+<br>
+
+> ⚠️ **Note:**  
+> If double-tap reset does not work (for example, if the running application has corrupted necessary flash metadata), you may need to manually reflash the TinyUF2 bootloader using a SWD debug tool such as J-Link or OpenOCD.  
+> Refer to your board's documentation for additional recovery options if needed.
+
+<br>
+
+## Port Directory Structure
+
+Example directory tree for the MAX32650 port:
+
+```
+max32650
+├── Makefile
+├── README.md
+├── _build
+├── apps
+│   ├── blinky
+│   │   ├── Makefile
+│   │   └── _build
+│   ├── erase_firmware
+│   │   ├── Makefile
+│   │   └── _build
+│   └── self_update
+│       ├── Makefile
+│       └── _build
+├── board_flash.c
+├── boards
+│   ├── max32650evkit
+│   │   ├── board.h
+│   │   └── board.mk
+│   └── max32650fthr
+│       ├── board.h
+│       └── board.mk
+├── boards.c
+├── boards.h
+├── linker
+│   ├── max32650_app.ld
+│   ├── max32650_boot.ld
+│   └── max32650_common.ld
+├── port.mk
+└── tusb_config.h
+```

--- a/ports/max32650/port.mk
+++ b/ports/max32650/port.mk
@@ -103,10 +103,14 @@ INC += \
 flash: flash-jlink
 erase: erase-jlink
 
+
 # Optional flash option when running within an installed MSDK to use OpenOCD
 # Mainline OpenOCD does not yet have the MAX32's flash algorithm integrated.
 # If the MSDK is installed, flash-msdk can be run to utilize the the modified
 # openocd with the algorithms
+
+
+
 MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
 flash-msdk: $(BUILD)/$(OUTNAME).elf
 	$(MAXIM_PATH)/Tools/OpenOCD/openocd -s $(MAXIM_PATH)/Tools/OpenOCD/scripts \

--- a/ports/max32666/.gitignore
+++ b/ports/max32666/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build logs
+logs/
+*.log

--- a/ports/max32666/Makefile
+++ b/ports/max32666/Makefile
@@ -5,28 +5,82 @@ include ../make.mk
 include port.mk
 include ../rules.mk
 
-#------------------------------------------
+################################################################################
+# Optional Save Log Support
+################################################################################
+ifeq ($(SAVELOG),1)
+    TIMESTAMP := $(shell date +%Y%m%d_%H%M%S)
+    LOG_SUFFIX = _$(TIMESTAMP).log
+endif
+
+################################################################################
 # Self-update
-#------------------------------------------
-self-update: $(BUILD)/$(OUTNAME).bin
-	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py --carray $^ -o apps/self_update/_build/bootloader_bin.c
+################################################################################
+self-update:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update
+	@echo "Building self-update application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update/self-update$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update uf2
+endif
 
 self-update-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update-clean
+	@echo "Cleaning self-update application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update-clean/self-update-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update clean
+endif
 
-#---------- Erase Firmware ----------
-# Compile apps/erase_firmware/erase_firmware.c
+################################################################################
+# Erase Firmware
+################################################################################
 erase-firmware:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware
+	@echo "Building erase-firmware application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware/erase-firmware$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware uf2
+endif
 
 erase-firmware-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware-clean
+	@echo "Cleaning erase-firmware application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware-clean/erase-firmware-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware clean
+endif
 
-#---------- Blinky ----------
-# Compile apps/blinky/blinky.c
+################################################################################
+# Blinky
+################################################################################
 blinky:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky
+	@echo "Building blinky application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky/blinky$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky uf2
+endif
 
 blinky-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky-clean
+	@echo "Cleaning blinky application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky-clean/blinky-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky clean
+endif
+
+################################################################################
+# Clean Logs
+################################################################################
+clean-logs:
+	@echo "Cleaning all log files..."
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/self_update/logs
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/blinky/logs

--- a/ports/max32666/README.md
+++ b/ports/max32666/README.md
@@ -1,0 +1,376 @@
+# TinyUF2 - MAX32666 Port
+
+This folder contains the port of TinyUF2 for Analog Devices' MAX32666 MCU.
+
+## Navigation
+
+- [Requirements](#requirements)
+  - [Requirements for Linux/macOS (Generic)](#requirements-for-linuxmacos-generic)
+  - [Requirements for Windows (Using MSDK — Optional)](#requirements-for-windows-using-msdk--optional)
+- [MSDK Windows Environment Setup](#msdk-windows-environment-setup)
+- [Available Boards](#available-boards)
+- [Building the Bootloader](#building-the-bootloader)
+- [Building Demo Applications](#building-demo-applications)
+  - [To Build Individual Applications](#to-build-individual-applications)
+  - [To Clean Individual Applications](#to-clean-individual-applications)
+- [Flashing the Bootloader](#flashing-the-bootloader)
+  - [J-Link vs OpenOCD](#j-link-vs-openocd)
+  - [Flashing with J-Link](#1-j-link-default)
+  - [Flashing with OpenOCD (MSDK)](#2-openocd-from-msdk-optional)
+- [Notes on SAVELOG=1](#notes-on-savelog1)
+- [Cleaning Logs](#cleaning-logs)
+- [Flashing Example Applications](#flashing-example-applications)
+  - [Flashing via Drag-and-Drop](#flashing-via-drag-and-drop)
+  - [Re-Entering Bootloader Mode](#re-entering-bootloader-mode)
+- [Port Directory Structure](#port-directory-structure)
+
+
+<br>
+
+## Requirements
+
+This guide focuses on building TinyUF2 for Analog Devices' MAX32 parts.  
+It is written with Windows users in mind using the **MSDK**, but TinyUF2 is fully portable and can be built with a standard toolchain on Linux and macOS.
+
+
+### Requirements for Linux/macOS (Generic)
+
+You do **not** need the MSDK to build TinyUF2 on Linux or macOS.  
+All you need is a basic toolchain:
+
+- **GNU ARM Toolchain** (`arm-none-eabi-gcc`) available in your `PATH`
+- **make**
+- **git** (required for submodules)
+- **SDK Depencencies** 
+
+
+### Installing SDK Dependencies
+```bash 
+python tools/get_deps.py max32
+```
+or
+```bash
+python tools/get_deps.py --board max32666evkit
+```
+
+#### macOS Dependency Install
+```bash
+brew install arm-none-eabi-gcc make git
+```
+
+#### Ubuntu Dependency Install
+```bash
+sudo apt update
+sudo apt install gcc-arm-none-eabi make git
+```
+
+<br><br>
+
+```bash
+# Example usage:
+cd ports/max32666evkit/
+make BOARD=max32666evkit all
+---
+
+### Requirements for Windows (Using MSDK — Optional)
+
+If you're using Analog Devices' [MSDK](https://github.com/analogdevicesinc/msdk), it includes:
+
+- Pre-configured **GNU ARM Toolchain**
+- **MSYS2** terminal environment
+- Optional **OpenOCD** with MAX32 flash support
+
+Download MSDK from:  
+[Analog Devices Embedded Software Center (MaximSDK)](https://www.analog.com/en/resources/evaluation-hardware-and-software/embedded-development-software/software-download.html?swpart=SFW0010820B)
+
+You will need:
+
+- ARM GNU Toolchain (`arm-none-eabi-gcc`) — *included with MSDK*
+- `make`:
+  - MSDK MSYS2: `C:/MaximSDK/Tools/MSYS2/usr/bin/make.exe`
+  - System-wide MSYS2: `C:/msys64/usr/bin/make.exe`
+- `git` (may need to be installed inside MSYS2):
+  ```bash
+  pacman -S git
+  ```
+
+If needed, set `MAXIM_PATH` to point to your MSDK installation:
+
+```bash
+export MAXIM_PATH=/c/MaximSDK
+```
+
+
+<br>
+
+## MSDK (Windows) Environment Setup
+
+### 1. Using MSDK's MSYS2
+
+Open MSYS2 (`mingw32.exe` or `mingw64.exe`) from:
+
+```
+C:/MaximSDK/Tools/MSYS2/
+```
+
+No further setup is needed — the required ARM toolchain should be available.
+
+### 2. Using a System-wide MSYS2 or mingw (Alternative)
+
+If you are using your own MSYS2 or mingw installation (not MSDK’s MSYS2), you must manually add the MSDK's GNUTools to your PATH before building:
+
+```bash
+export PATH="/c/MaximSDK/Tools/GNUTools/10.3/bin/:$PATH"
+```
+
+Or in one-line command for building:
+
+```bash
+PATH="/c/MaximSDK/Tools/GNUTools/10.3/bin/:$PATH" make BOARD=max32666evkit blinky erase-firmware self-update
+```
+
+(Adjust the path if your MSDK installation is in a different location.)
+
+<br>
+
+## Available Boards
+
+Each port supports multiple hardware platforms.  
+The specific boards available for each device can be found inside:
+
+```
+ports/maxxxxxx/boards/
+```
+
+For example, for MAX32666:
+
+```
+tinyuf2/ports/max32666/boards/
+    max32666evkit
+    max32666fthr
+```
+
+When building or flashing, make sure to specify a valid `BOARD` name from the available list:
+
+```bash
+make BOARD=max32666evkit all
+make BOARD=max32666evkit flash
+```
+
+Otherwise, the build will fail if an invalid board name is provided.
+
+<br>
+
+## Building the Bootloader
+
+1. Open your MSYS2 terminal (preferably MSDK’s).
+2. Navigate to the port folder for MAX32666:
+
+```bash
+cd ports/max32666
+```
+
+3. Build the TinyUF2 bootloader:
+
+```bash
+make BOARD=max32666evkit all
+```
+
+
+Output files will appear in `_build/` and build logs under `apps/$(APP)/logs/`.
+
+
+<br>
+
+## Building Demo Applications
+
+TinyUF2 for MAX32666 includes three demo applications:
+- **Blinky** (`apps/blinky`)
+- **Erase Firmware** (`apps/erase_firmware`)
+- **Self-Update** (`apps/self_update`)
+
+### To Build Individual Applications:
+
+```bash
+make BOARD=max32666evkit blinky
+make BOARD=max32666evkit erase-firmware
+make BOARD=max32666evkit self-update
+```
+
+### To Clean Individual Applications:
+
+```bash
+make BOARD=max32666evkit blinky-clean
+make BOARD=max32666evkit erase-firmware-clean
+make BOARD=max32666evkit self-update-clean
+```
+
+You can add `SAVELOG=1` to any of these commands to generate a saved build log.
+
+```bash
+ make BOARD=max32666evkit SAVELOG=1 blinky erase-firmware self-update
+```
+
+<br>
+
+## Flashing the Bootloader
+
+
+### J-Link vs OpenOCD
+
+TinyUF2 supports two main ways to flash firmware:
+
+- **J-Link** (default): Uses SEGGER's proprietary debug probe. Supports fast, reliable flashing and debugging over SWD or JTAG. Requires a J-Link device and SEGGER drivers.
+  
+- **OpenOCD (MSDK)**: Open-source tool for programming/debugging via CMSIS-DAP or other adapters.  
+  The MSDK includes a custom version of OpenOCD that supports MAX32 devices, since official OpenOCD does not yet have MAX32 flash algorithm support.
+
+
+<br>
+
+`make flash` will use **J-Link** by default.  
+`make flash-msdk` to use the **OpenOCD** path with CMSIS-DAP.
+
+
+
+### 1. J-Link (default)
+
+To flash using a J-Link debugger:
+
+```bash
+make BOARD=max32666evkit flash
+```
+
+To erase before flashing:
+
+```bash
+make BOARD=max32666evkit erase flash
+```
+
+### 2. OpenOCD from MSDK (optional)
+
+If you prefer OpenOCD and you have it installed through MSDK:
+
+```bash
+make BOARD=max32666evkit flash-msdk
+```
+
+Make sure `MAXIM_PATH` is correctly set to the MSDK base folder. If your default installation of the MSDK is not `C:/MaximSDK` you can pass the MaximSDK directory's location...
+
+```bash
+make BOARD=max32666evkit MAXIM_PATH=C:/MaximSDK flash-msdk
+```
+
+> ⚠️ **Note:**
+> Optional flash option when running within an installed MSDK to use OpenOCD. Mainline OpenOCD does not yet have the MAX32's flash algorithm integrated. If the MSDK is installed, flash-msdk can be run to utilize the the modified openocd with the algorithms.
+
+<br>
+
+## Notes on SAVELOG=1
+
+Log export options are available for demo apps.
+
+If `SAVELOG=1` is set during a build:
+
+- Output logs are automatically saved into a `logs/` folder inside each application.
+- Each application target (e.g., `blinky`, `blinky-clean`) has its own separate subfolder and timestamped `.log` files.
+- Log files are ignored from Git version control.
+
+Example:
+
+```
+apps/blinky/logs/blinky/blinky_20250425_134500.log
+apps/blinky/logs/blinky-clean/blinky-clean_20250425_134512.log
+```
+
+<br>
+
+## Cleaning Logs
+
+You can remove all saved build logs across all apps by running:
+
+```bash
+make BOARD=max32666evkit clean-logs
+```
+
+This deletes all `logs/` directories under `apps/blinky`, `apps/erase_firmware`, and `apps/self_update`.
+
+
+<br>
+
+
+## Flashing Example Applications
+
+After building any of the demo applications (Blinky, Erase Firmware, or Self-Update), a UF2 file will be generated in:
+
+```
+apps/<application>/_build/<board>/<application>-<board>.uf2
+```
+
+For example:
+
+```
+apps/blinky/_build/<board>/blinky-<board>.uf2
+```
+
+### Flashing via Drag-and-Drop
+
+1. **Enter bootloader mode** on your board:
+   - Typically, perform a **double-tap on the reset button** within **500 milliseconds**.
+   - The board will appear as a **USB mass storage device** (for example, named `TINYUF2`) in your operating system's **File Explorer** (Windows) or **Finder** (macOS) or **File Manager** (Linux).
+
+2. **Using your file explorer**, locate the `.uf2` file you built, and **drag and drop** it onto the mounted TinyUF2 USB drive.
+
+3. The board will automatically reboot and begin running the new application.
+
+### Re-Entering Bootloader Mode
+
+To flash a different application or return to bootloader mode:
+
+- Perform another **double-tap** of the reset button within 500 milliseconds.
+- The board will reappear as a USB mass storage device for new UF2 flashing.
+
+<br>
+
+> ⚠️ **Note:**  
+> If double-tap reset does not work (for example, if the running application has corrupted necessary flash metadata), you may need to manually reflash the TinyUF2 bootloader using a SWD debug tool such as J-Link or OpenOCD.  
+> Refer to your board's documentation for additional recovery options if needed.
+
+<br>
+
+## Port Directory Structure
+
+Example directory tree for the MAX32666 port:
+
+```
+max32666
+├── Makefile
+├── README.md
+├── _build
+├── apps
+│   ├── blinky
+│   │   ├── Makefile
+│   │   └── _build
+│   ├── erase_firmware
+│   │   ├── Makefile
+│   │   └── _build
+│   └── self_update
+│       ├── Makefile
+│       └── _build
+├── board_flash.c
+├── boards
+│   ├── max32666evkit
+│   │   ├── board.h
+│   │   └── board.mk
+│   └── max32666fthr
+│       ├── board.h
+│       └── board.mk
+├── boards.c
+├── boards.h
+├── linker
+│   ├── max32666_app.ld
+│   ├── max32666_boot.ld
+│   └── max32666_common.ld
+├── port.mk
+└── tusb_config.h
+```

--- a/ports/max32666/port.mk
+++ b/ports/max32666/port.mk
@@ -105,6 +105,7 @@ erase: erase-jlink
 # Mainline OpenOCD does not yet have the MAX32's flash algorithm integrated.
 # If the MSDK is installed, flash-msdk can be run to utilize the the modified
 # openocd with the algorithms
+
 MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
 flash-msdk: $(BUILD)/$(OUTNAME).elf
 	$(MAXIM_PATH)/Tools/OpenOCD/openocd -s $(MAXIM_PATH)/Tools/OpenOCD/scripts \

--- a/ports/max32690/.gitignore
+++ b/ports/max32690/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build logs
+logs/
+*.log

--- a/ports/max32690/Makefile
+++ b/ports/max32690/Makefile
@@ -5,28 +5,82 @@ include ../make.mk
 include port.mk
 include ../rules.mk
 
-#------------------------------------------
+################################################################################
+# Optional Save Log Support
+################################################################################
+ifeq ($(SAVELOG),1)
+    TIMESTAMP := $(shell date +%Y%m%d_%H%M%S)
+    LOG_SUFFIX = _$(TIMESTAMP).log
+endif
+
+################################################################################
 # Self-update
-#------------------------------------------
-self-update: $(BUILD)/$(OUTNAME).bin
-	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py --carray $^ -o apps/self_update/_build/bootloader_bin.c
+################################################################################
+self-update:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update
+	@echo "Building self-update application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update/self-update$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update uf2
+endif
 
 self-update-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update-clean
+	@echo "Cleaning self-update application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update-clean/self-update-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update clean
+endif
 
-#---------- Erase Firmware ----------
-# Compile apps/erase_firmware/erase_firmware.c
+################################################################################
+# Erase Firmware
+################################################################################
 erase-firmware:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware
+	@echo "Building erase-firmware application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware/erase-firmware$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware uf2
+endif
 
 erase-firmware-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware-clean
+	@echo "Cleaning erase-firmware application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware-clean/erase-firmware-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware clean
+endif
 
-#---------- Blinky ----------
-# Compile apps/blinky/blinky.c
+################################################################################
+# Blinky
+################################################################################
 blinky:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky
+	@echo "Building blinky application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky/blinky$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky uf2
+endif
 
 blinky-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky-clean
+	@echo "Cleaning blinky application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky-clean/blinky-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky clean
+endif
+
+################################################################################
+# Clean Logs
+################################################################################
+clean-logs:
+	@echo "Cleaning all log files..."
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/self_update/logs
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/blinky/logs

--- a/ports/max32690/README.md
+++ b/ports/max32690/README.md
@@ -1,0 +1,379 @@
+# TinyUF2 - MAX32690 Port
+
+This folder contains the port of TinyUF2 for Analog Devices' MAX32690 MCU.
+
+## Navigation
+
+- [Requirements](#requirements)
+  - [Requirements for Linux/macOS (Generic)](#requirements-for-linuxmacos-generic)
+  - [Requirements for Windows (Using MSDK — Optional)](#requirements-for-windows-using-msdk--optional)
+- [MSDK Windows Environment Setup](#msdk-windows-environment-setup)
+- [Available Boards](#available-boards)
+- [Building the Bootloader](#building-the-bootloader)
+- [Building Demo Applications](#building-demo-applications)
+  - [To Build Individual Applications](#to-build-individual-applications)
+  - [To Clean Individual Applications](#to-clean-individual-applications)
+- [Flashing the Bootloader](#flashing-the-bootloader)
+  - [J-Link vs OpenOCD](#j-link-vs-openocd)
+  - [Flashing with J-Link](#1-j-link-default)
+  - [Flashing with OpenOCD (MSDK)](#2-openocd-from-msdk-optional)
+- [Notes on SAVELOG=1](#notes-on-savelog1)
+- [Cleaning Logs](#cleaning-logs)
+- [Flashing Example Applications](#flashing-example-applications)
+  - [Flashing via Drag-and-Drop](#flashing-via-drag-and-drop)
+  - [Re-Entering Bootloader Mode](#re-entering-bootloader-mode)
+- [Port Directory Structure](#port-directory-structure)
+
+
+<br>
+
+## Requirements
+
+This guide focuses on building TinyUF2 for Analog Devices' MAX32 parts.  
+It is written with Windows users in mind using the **MSDK**, but TinyUF2 is fully portable and can be built with a standard toolchain on Linux and macOS.
+
+
+### Requirements for Linux/macOS (Generic)
+
+You do **not** need the MSDK to build TinyUF2 on Linux or macOS.  
+All you need is a basic toolchain:
+
+- **GNU ARM Toolchain** (`arm-none-eabi-gcc`) available in your `PATH`
+- **make**
+- **git** (required for submodules)
+- **SDK Depencencies** 
+
+
+### Installing SDK Dependencies
+```bash 
+python tools/get_deps.py max32
+```
+or
+```bash
+python tools/get_deps.py --board apard32690
+```
+
+
+#### macOS Dependency Install
+```bash
+brew install arm-none-eabi-gcc make git
+```
+
+#### Ubuntu Dependency Install
+```bash
+sudo apt update
+sudo apt install gcc-arm-none-eabi make git
+```
+
+<br><br>
+
+```bash
+# Example usage:
+cd ports/max32690/
+make BOARD=apard32690 all
+```
+
+---
+
+### Requirements for Windows (Using MSDK — Optional)
+
+If you're using Analog Devices' [MSDK](https://github.com/analogdevicesinc/msdk), it includes:
+
+- Pre-configured **GNU ARM Toolchain**
+- **MSYS2** terminal environment
+- Optional **OpenOCD** with MAX32 flash support
+
+Download MSDK from:  
+[Analog Devices Embedded Software Center (MaximSDK)](https://www.analog.com/en/resources/evaluation-hardware-and-software/embedded-development-software/software-download.html?swpart=SFW0010820B)
+
+You will need:
+
+- ARM GNU Toolchain (`arm-none-eabi-gcc`) — *included with MSDK*
+- `make`:
+  - MSDK MSYS2: `C:/MaximSDK/Tools/MSYS2/usr/bin/make.exe`
+  - System-wide MSYS2: `C:/msys64/usr/bin/make.exe`
+- `git` (may need to be installed inside MSYS2):
+  ```bash
+  pacman -S git
+  ```
+
+If needed, set `MAXIM_PATH` to point to your MSDK installation:
+
+```bash
+export MAXIM_PATH=/c/MaximSDK
+```
+
+
+<br>
+
+## MSDK (Windows) Environment Setup
+
+### 1. Using MSDK's MSYS2
+
+Open MSYS2 (`mingw32.exe` or `mingw64.exe`) from:
+
+```
+C:/MaximSDK/Tools/MSYS2/
+```
+
+No further setup is needed — the required ARM toolchain should be available.
+
+### 2. Using a System-wide MSYS2 or mingw (Alternative)
+
+If you are using your own MSYS2 or mingw installation (not MSDK’s MSYS2), you must manually add the MSDK's GNUTools to your PATH before building:
+
+```bash
+export PATH="/c/MaximSDK/Tools/GNUTools/10.3/bin/:$PATH"
+```
+
+Or in one-line command for building:
+
+```bash
+PATH="/c/MaximSDK/Tools/GNUTools/10.3/bin/:$PATH" make BOARD=apard32690 blinky erase-firmware self-update
+```
+
+(Adjust the path if your MSDK installation is in a different location.)
+
+<br>
+
+## Available Boards
+
+Each port supports multiple hardware platforms.  
+The specific boards available for each device can be found inside:
+
+```
+ports/maxxxxxx/boards/
+```
+
+For example, for MAX32690:
+
+```
+tinyuf2/ports/max32690/boards/
+    apard32690
+    max32690evkit
+```
+
+When building or flashing, make sure to specify a valid `BOARD` name from the available list:
+
+```bash
+make BOARD=apard32690 all
+make BOARD=apard32690 flash
+```
+
+Otherwise, the build will fail if an invalid board name is provided.
+
+<br>
+
+## Building the Bootloader
+
+1. Open your MSYS2 terminal (preferably MSDK’s).
+2. Navigate to the port folder for MAX32690:
+
+```bash
+cd ports/max32690
+```
+
+3. Build the TinyUF2 bootloader:
+
+```bash
+make BOARD=apard32690 all
+```
+
+
+Output files will appear in `_build/` and build logs under `apps/$(APP)/logs/`.
+
+
+<br>
+
+## Building Demo Applications
+
+TinyUF2 for MAX32690 includes three demo applications:
+- **Blinky** (`apps/blinky`)
+- **Erase Firmware** (`apps/erase_firmware`)
+- **Self-Update** (`apps/self_update`)
+
+### To Build Individual Applications:
+
+```bash
+make BOARD=apard32690 blinky
+make BOARD=apard32690 erase-firmware
+make BOARD=apard32690 self-update
+```
+
+### To Clean Individual Applications:
+
+```bash
+make BOARD=apard32690 blinky-clean
+make BOARD=apard32690 erase-firmware-clean
+make BOARD=apard32690 self-update-clean
+```
+
+You can add `SAVELOG=1` to any of these commands to generate a saved build log.
+
+```bash
+ make BOARD=apard32690 SAVELOG=1 blinky erase-firmware self-update
+```
+
+<br>
+
+## Flashing the Bootloader
+
+
+### J-Link vs OpenOCD
+
+TinyUF2 supports two main ways to flash firmware:
+
+- **J-Link** (default): Uses SEGGER's proprietary debug probe. Supports fast, reliable flashing and debugging over SWD or JTAG. Requires a J-Link device and SEGGER drivers.
+  
+- **OpenOCD (MSDK)**: Open-source tool for programming/debugging via CMSIS-DAP or other adapters.  
+  The MSDK includes a custom version of OpenOCD that supports MAX32 devices, since official OpenOCD does not yet have MAX32 flash algorithm support.
+
+
+<br>
+
+`make flash` will use **J-Link** by default.  
+`make flash-msdk` to use the **OpenOCD** path with CMSIS-DAP.
+
+
+
+### 1. J-Link (default)
+
+To flash using a J-Link debugger:
+
+```bash
+make BOARD=apard32690 flash
+```
+
+To erase before flashing:
+
+```bash
+make BOARD=apard32690 erase flash
+```
+
+### 2. OpenOCD from MSDK (optional)
+
+If you prefer OpenOCD and you have it installed through MSDK:
+
+```bash
+make BOARD=apard32690 flash-msdk
+```
+
+Make sure `MAXIM_PATH` is correctly set to the MSDK base folder. If your default installation of the MSDK is not `C:/MaximSDK` you can pass the MaximSDK directory's location...
+
+```bash
+make BOARD=apard32690 MAXIM_PATH=C:/MaximSDK flash-msdk
+```
+
+> ⚠️ **Note:**
+> Optional flash option when running within an installed MSDK to use OpenOCD. Mainline OpenOCD does not yet have the MAX32's flash algorithm integrated. If the MSDK is installed, flash-msdk can be run to utilize the the modified openocd with the algorithms.
+
+<br>
+
+## Notes on SAVELOG=1
+
+Log export options are available for demo apps.
+
+If `SAVELOG=1` is set during a build:
+
+- Output logs are automatically saved into a `logs/` folder inside each application.
+- Each application target (e.g., `blinky`, `blinky-clean`) has its own separate subfolder and timestamped `.log` files.
+- Log files are ignored from Git version control.
+
+Example:
+
+```
+apps/blinky/logs/blinky/blinky_20250425_134500.log
+apps/blinky/logs/blinky-clean/blinky-clean_20250425_134512.log
+```
+
+<br>
+
+## Cleaning Logs
+
+You can remove all saved build logs across all apps by running:
+
+```bash
+make BOARD=apard32690 clean-logs
+```
+
+This deletes all `logs/` directories under `apps/blinky`, `apps/erase_firmware`, and `apps/self_update`.
+
+
+<br>
+
+
+## Flashing Example Applications
+
+After building any of the demo applications (Blinky, Erase Firmware, or Self-Update), a UF2 file will be generated in:
+
+```
+apps/<application>/_build/<board>/<application>-<board>.uf2
+```
+
+For example:
+
+```
+apps/blinky/_build/<board>/blinky-<board>.uf2
+```
+
+### Flashing via Drag-and-Drop
+
+1. **Enter bootloader mode** on your board:
+   - Typically, perform a **double-tap on the reset button** within **500 milliseconds**.
+   - The board will appear as a **USB mass storage device** (for example, named `TINYUF2`) in your operating system's **File Explorer** (Windows) or **Finder** (macOS) or **File Manager** (Linux).
+
+2. **Using your file explorer**, locate the `.uf2` file you built, and **drag and drop** it onto the mounted TinyUF2 USB drive.
+
+3. The board will automatically reboot and begin running the new application.
+
+### Re-Entering Bootloader Mode
+
+To flash a different application or return to bootloader mode:
+
+- Perform another **double-tap** of the reset button within 500 milliseconds.
+- The board will reappear as a USB mass storage device for new UF2 flashing.
+
+<br>
+
+> ⚠️ **Note:**  
+> If double-tap reset does not work (for example, if the running application has corrupted necessary flash metadata), you may need to manually reflash the TinyUF2 bootloader using a SWD debug tool such as J-Link or OpenOCD.  
+> Refer to your board's documentation for additional recovery options if needed.
+
+<br>
+
+## Port Directory Structure
+
+Example directory tree for the MAX32690 port:
+
+```
+max32690
+├── Makefile
+├── README.md
+├── _build
+├── apps
+│   ├── blinky
+│   │   ├── Makefile
+│   │   └── _build
+│   ├── erase_firmware
+│   │   ├── Makefile
+│   │   └── _build
+│   └── self_update
+│       ├── Makefile
+│       └── _build
+├── board_flash.c
+├── boards
+│   ├── apard32690
+│   │   ├── board.h
+│   │   └── board.mk
+│   └── max32690evkit
+│       ├── board.h
+│       └── board.mk
+├── boards.c
+├── boards.h
+├── linker
+│   ├── max32690_app.ld
+│   ├── max32690_boot.ld
+│   └── max32690_common.ld
+├── port.mk
+└── tusb_config.h
+```

--- a/ports/max32690/port.mk
+++ b/ports/max32690/port.mk
@@ -108,6 +108,9 @@ erase: erase-jlink
 # Mainline OpenOCD does not yet have the MAX32's flash algorithm integrated.
 # If the MSDK is installed, flash-msdk can be run to utilize the the modified
 # openocd with the algorithms
+
+
+# Convert Windows-style \ to /
 MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
 flash-msdk: $(BUILD)/$(OUTNAME).elf
 	$(MAXIM_PATH)/Tools/OpenOCD/openocd -s $(MAXIM_PATH)/Tools/OpenOCD/scripts \

--- a/ports/max78002/.gitignore
+++ b/ports/max78002/.gitignore
@@ -1,0 +1,3 @@
+# Ignore build logs
+logs/
+*.log

--- a/ports/max78002/Makefile
+++ b/ports/max78002/Makefile
@@ -5,28 +5,82 @@ include ../make.mk
 include port.mk
 include ../rules.mk
 
-#------------------------------------------
+################################################################################
+# Optional Save Log Support
+################################################################################
+ifeq ($(SAVELOG),1)
+    TIMESTAMP := $(shell date +%Y%m%d_%H%M%S)
+    LOG_SUFFIX = _$(TIMESTAMP).log
+endif
+
+################################################################################
 # Self-update
-#------------------------------------------
-self-update: $(BUILD)/$(OUTNAME).bin
-	$(PYTHON3) $(TOP)/lib/uf2/utils/uf2conv.py --carray $^ -o apps/self_update/_build/bootloader_bin.c
+################################################################################
+self-update:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update
+	@echo "Building self-update application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update/self-update$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update uf2
+endif
 
 self-update-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update-clean
+	@echo "Cleaning self-update application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/self_update/logs/self-update-clean/self-update-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/self_update clean
+endif
 
-#---------- Erase Firmware ----------
-# Compile apps/erase_firmware/erase_firmware.c
+################################################################################
+# Erase Firmware
+################################################################################
 erase-firmware:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware
+	@echo "Building erase-firmware application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware/erase-firmware$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware uf2
+endif
 
 erase-firmware-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware-clean
+	@echo "Cleaning erase-firmware application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs/erase-firmware-clean/erase-firmware-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/erase_firmware clean
+endif
 
-#---------- Blinky ----------
-# Compile apps/blinky/blinky.c
+################################################################################
+# Blinky
+################################################################################
 blinky:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky
+	@echo "Building blinky application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky uf2 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky/blinky$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky uf2
+endif
 
 blinky-clean:
+	@mkdir -p $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky-clean
+	@echo "Cleaning blinky application..."
+ifeq ($(SAVELOG),1)
+	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky clean 2>&1 | tee $(TOP)/$(PORT_DIR)/apps/blinky/logs/blinky-clean/blinky-clean$(LOG_SUFFIX)
+else
 	$(MAKE) -C $(TOP)/$(PORT_DIR)/apps/blinky clean
+endif
+
+################################################################################
+# Clean Logs
+################################################################################
+clean-logs:
+	@echo "Cleaning all log files..."
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/self_update/logs
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/erase_firmware/logs
+	@rm -rf $(TOP)/$(PORT_DIR)/apps/blinky/logs

--- a/ports/max78002/README.md
+++ b/ports/max78002/README.md
@@ -1,0 +1,364 @@
+# TinyUF2 - MAX78002 Port
+
+This folder contains the port of TinyUF2 for Analog Devices' MAX78002 MCU.
+
+## Navigation
+
+- [Requirements](#requirements)
+  - [Requirements for Linux/macOS (Generic)](#requirements-for-linuxmacos-generic)
+  - [Requirements for Windows (Using MSDK — Optional)](#requirements-for-windows-using-msdk--optional)
+- [MSDK Windows Environment Setup](#msdk-windows-environment-setup)
+- [Available Boards](#available-boards)
+- [Building the Bootloader](#building-the-bootloader)
+- [Building Demo Applications](#building-demo-applications)
+  - [To Build Individual Applications](#to-build-individual-applications)
+  - [To Clean Individual Applications](#to-clean-individual-applications)
+- [Flashing the Bootloader](#flashing-the-bootloader)
+  - [J-Link vs OpenOCD](#j-link-vs-openocd)
+  - [Flashing with J-Link](#1-j-link-default)
+  - [Flashing with OpenOCD (MSDK)](#2-openocd-from-msdk-optional)
+- [Notes on SAVELOG=1](#notes-on-savelog1)
+- [Cleaning Logs](#cleaning-logs)
+- [Flashing Example Applications](#flashing-example-applications)
+  - [Flashing via Drag-and-Drop](#flashing-via-drag-and-drop)
+  - [Re-Entering Bootloader Mode](#re-entering-bootloader-mode)
+- [Port Directory Structure](#port-directory-structure)
+
+<br>
+
+## Requirements
+
+This guide focuses on building TinyUF2 for Analog Devices' MAX32 parts.  
+It is written with Windows users in mind using the **MSDK**, but TinyUF2 is fully portable and can be built with a standard toolchain on Linux and macOS.
+
+### Requirements for Linux/macOS (Generic)
+
+You do **not** need the MSDK to build TinyUF2 on Linux or macOS.  
+All you need is a basic toolchain:
+
+- **GNU ARM Toolchain** (`arm-none-eabi-gcc`) available in your `PATH`
+- **make**
+- **git** (required for submodules)
+- **SDK Depencencies** 
+
+
+### Installing SDK Dependencies
+```bash 
+python tools/get_deps.py max32
+```
+or
+```bash
+python tools/get_deps.py --board max78002evkit
+```
+
+
+#### macOS Dependency Install
+```bash
+brew install arm-none-eabi-gcc make git
+```
+
+#### Ubuntu Dependency Install
+```bash
+sudo apt update
+sudo apt install gcc-arm-none-eabi make git
+```
+
+<br><br>
+
+```bash
+# Example usage:
+cd ports/max78002evkit/
+make BOARD=max78002evkit all
+```
+
+---
+
+### Requirements for Windows (Using MSDK — Optional)
+
+If you're using Analog Devices' [MSDK](https://github.com/analogdevicesinc/msdk), it includes:
+
+- Pre-configured **GNU ARM Toolchain**
+- **MSYS2** terminal environment
+- Optional **OpenOCD** with MAX32 flash support
+
+Download MSDK from:  
+[Analog Devices Embedded Software Center (MaximSDK)](https://www.analog.com/en/resources/evaluation-hardware-and-software/embedded-development-software/software-download.html?swpart=SFW0010820B)
+
+You will need:
+
+- ARM GNU Toolchain (`arm-none-eabi-gcc`) — *included with MSDK*
+- `make`:
+  - MSDK MSYS2: `C:/MaximSDK/Tools/MSYS2/usr/bin/make.exe`
+  - System-wide MSYS2: `C:/msys64/usr/bin/make.exe`
+- `git` (may need to be installed inside MSYS2):
+  ```bash
+  pacman -S git
+  ```
+
+If needed, set `MAXIM_PATH` to point to your MSDK installation:
+
+```bash
+export MAXIM_PATH=/c/MaximSDK
+```
+
+<br>
+
+## MSDK (Windows) Environment Setup
+
+### 1. Using MSDK's MSYS2
+
+Open MSYS2 (`mingw32.exe` or `mingw64.exe`) from:
+
+```
+C:/MaximSDK/Tools/MSYS2/
+```
+
+No further setup is needed — the required ARM toolchain should be available.
+
+### 2. Using a System-wide MSYS2 or mingw (Alternative)
+
+If you are using your own MSYS2 or mingw installation (not MSDK’s MSYS2), you must manually add the MSDK's GNUTools to your PATH before building:
+
+```bash
+export PATH="/c/MaximSDK/Tools/GNUTools/10.3/bin/:$PATH"
+```
+
+Or in one-line command for building:
+
+```bash
+PATH="/c/MaximSDK/Tools/GNUTools/10.3/bin/:$PATH" make BOARD=max78002evkit blinky erase-firmware self-update
+```
+
+(Adjust the path if your MSDK installation is in a different location.)
+
+<br>
+
+## Available Boards
+
+Each port supports multiple hardware platforms.  
+The specific boards available for each device can be found inside:
+
+```
+ports/maxxxxxx/boards/
+```
+
+For example, for MAX78002:
+
+```
+tinyuf2/ports/max78002/boards/
+    max78002evkit
+```
+
+When building or flashing, make sure to specify a valid `BOARD` name from the available list:
+
+```bash
+make BOARD=max78002evkit all
+make BOARD=max78002evkit flash
+```
+
+Otherwise, the build will fail if an invalid board name is provided.
+
+<br>
+
+## Building the Bootloader
+
+1. Open your MSYS2 terminal (preferably MSDK’s).
+2. Navigate to the port folder for MAX78002:
+
+```bash
+cd ports/max78002
+```
+
+3. Build the TinyUF2 bootloader:
+
+```bash
+make BOARD=max78002evkit all
+```
+
+Output files will appear in `_build/` and build logs under `apps/$(APP)/logs/`.
+
+<br>
+
+## Building Demo Applications
+
+TinyUF2 for MAX78002 includes three demo applications:
+- **Blinky** (`apps/blinky`)
+- **Erase Firmware** (`apps/erase_firmware`)
+- **Self-Update** (`apps/self_update`)
+
+### To Build Individual Applications:
+
+```bash
+make BOARD=max78002evkit blinky
+make BOARD=max78002evkit erase-firmware
+make BOARD=max78002evkit self-update
+```
+
+### To Clean Individual Applications:
+
+```bash
+make BOARD=max78002evkit blinky-clean
+make BOARD=max78002evkit erase-firmware-clean
+make BOARD=max78002evkit self-update-clean
+```
+
+You can add `SAVELOG=1` to any of these commands to generate a saved build log.
+
+```bash
+ make BOARD=max78002evkit SAVELOG=1 blinky erase-firmware self-update
+```
+
+<br>
+
+## Flashing the Bootloader
+
+### J-Link vs OpenOCD
+
+TinyUF2 supports two main ways to flash firmware:
+
+- **J-Link** (default): Uses SEGGER's proprietary debug probe. Supports fast, reliable flashing and debugging over SWD or JTAG. Requires a J-Link device and SEGGER drivers.
+  
+- **OpenOCD (MSDK)**: Open-source tool for programming/debugging via CMSIS-DAP or other adapters.  
+  The MSDK includes a custom version of OpenOCD that supports MAX32 devices, since official OpenOCD does not yet have MAX32 flash algorithm support.
+
+<br>
+
+`make flash` will use **J-Link** by default.  
+`make flash-msdk` to use the **OpenOCD** path with CMSIS-DAP.
+
+### 1. J-Link (default)
+
+To flash using a J-Link debugger:
+
+```bash
+make BOARD=max78002evkit flash
+```
+
+To erase before flashing:
+
+```bash
+make BOARD=max78002evkit erase flash
+```
+
+### 2. OpenOCD from MSDK (optional)
+
+If you prefer OpenOCD and you have it installed through MSDK:
+
+```bash
+make BOARD=max78002evkit flash-msdk
+```
+
+Make sure `MAXIM_PATH` is correctly set to the MSDK base folder. If your default installation of the MSDK is not `C:/MaximSDK` you can pass the MaximSDK directory's location...
+
+```bash
+make BOARD=max78002evkit MAXIM_PATH=C:/MaximSDK flash-msdk
+```
+
+> ⚠️ **Note:**
+> Optional flash option when running within an installed MSDK to use OpenOCD. Mainline OpenOCD does not yet have the MAX32's flash algorithm integrated. If the MSDK is installed, flash-msdk can be run to utilize the the modified openocd with the algorithms.
+
+<br>
+
+## Notes on SAVELOG=1
+
+Log export options are available for demo apps.
+
+If `SAVELOG=1` is set during a build:
+
+- Output logs are automatically saved into a `logs/` folder inside each application.
+- Each application target (e.g., `blinky`, `blinky-clean`) has its own separate subfolder and timestamped `.log` files.
+- Log files are ignored from Git version control.
+
+Example:
+
+```
+apps/blinky/logs/blinky/blinky_20250425_134500.log
+apps/blinky/logs/blinky-clean/blinky-clean_20250425_134512.log
+```
+
+<br>
+
+## Cleaning Logs
+
+You can remove all saved build logs across all apps by running:
+
+```bash
+make BOARD=max78002evkit clean-logs
+```
+
+This deletes all `logs/` directories under `apps/blinky`, `apps/erase_firmware`, and `apps/self_update`.
+
+<br>
+
+## Flashing Example Applications
+
+After building any of the demo applications (Blinky, Erase Firmware, or Self-Update), a UF2 file will be generated in:
+
+```
+apps/<application>/_build/<board>/<application>-<board>.uf2
+```
+
+For example:
+
+```
+apps/blinky/_build/<board>/blinky-<board>.uf2
+```
+
+### Flashing via Drag-and-Drop
+
+1. **Enter bootloader mode** on your board:
+   - Typically, perform a **double-tap on the reset button** within **500 milliseconds**.
+   - The board will appear as a **USB mass storage device** (for example, named `TINYUF2`) in your operating system's **File Explorer** (Windows) or **Finder** (macOS) or **File Manager** (Linux).
+
+2. **Using your file explorer**, locate the `.uf2` file you built, and **drag and drop** it onto the mounted TinyUF2 USB drive.
+
+3. The board will automatically reboot and begin running the new application.
+
+### Re-Entering Bootloader Mode
+
+To flash a different application or return to bootloader mode:
+
+- Perform another **double-tap** of the reset button within 500 milliseconds.
+- The board will reappear as a USB mass storage device for new UF2 flashing.
+
+<br>
+
+> ⚠️ **Note:**  
+> If double-tap reset does not work (for example, if the running application has corrupted necessary flash metadata), you may need to manually reflash the TinyUF2 bootloader using a SWD debug tool such as J-Link or OpenOCD.  
+> Refer to your board's documentation for additional recovery options if needed.
+
+<br>
+
+## Port Directory Structure
+
+Example directory tree for the MAX78002 port:
+
+```
+max78002
+├── Makefile
+├── README.md
+├── _build
+├── apps
+│   ├── blinky
+│   │   ├── Makefile
+│   │   └── _build
+│   ├── erase_firmware
+│   │   ├── Makefile
+│   │   └── _build
+│   └── self_update
+│       ├── Makefile
+│       └── _build
+├── board_flash.c
+├── boards
+│   ├── max78002evkit
+│   │   ├── board.h
+│   │   └── board.mk
+├── boards.c
+├── boards.h
+├── linker
+│   ├── max78002_app.ld
+│   ├── max78002_boot.ld
+│   └── max78002_common.ld
+├── port.mk
+└── tusb_config.h
+```

--- a/ports/max78002/port.mk
+++ b/ports/max78002/port.mk
@@ -111,6 +111,8 @@ erase: erase-jlink
 # Mainline OpenOCD does not yet have the MAX32's flash algorithm integrated.
 # If the MSDK is installed, flash-msdk can be run to utilize the the modified
 # openocd with the algorithms
+
+
 MAXIM_PATH := $(subst \,/,$(MAXIM_PATH))
 flash-msdk: $(BUILD)/$(OUTNAME).elf
 	$(MAXIM_PATH)/Tools/OpenOCD/openocd -s $(MAXIM_PATH)/Tools/OpenOCD/scripts \


### PR DESCRIPTION
## Summary

This PR enhances the existing MAX32690 TinyUF2 port by adding developer-focused improvements to documentation, environment setup, and build logging. Key changes include:

- ✅ Added detailed instructions to the README covering:
  - Compiling the bootloader
  - Compiling and flashing example apps
  - Required tools and environment setup (Windows/Linux)
- ✅ Introduced the `SAVELOG=1` build flag to export build/flash logs for blinky, self-update, and erase-firmware apps inside the MAX32 ports 
- ✅ Included `.gitignore` updates to exclude generated log files
- ✅ Fixed typos and improved formatting in the README and navigation
- ✅ Verified and refined changes after code merge from `rescued-add-max32`

These changes aim to improve developer onboarding and traceability of build steps when using the MAX32690 port.

## Checklist (✅ = complete)

- [x] Provided specific title describing the change
- [x] Added relevant board build instructions
- [x] Confirmed `UF2_BOARD_ID` format (if applicable)
- [x] Included relevant `.gitignore` updates
